### PR TITLE
Fix double-promotion issues.

### DIFF
--- a/src/libdw1000.c
+++ b/src/libdw1000.c
@@ -829,14 +829,14 @@ static float calculatePower(float base, float N, uint8_t pulseFrequency) {
   float A, corrFac;
 
 	if(TX_PULSE_FREQ_16MHZ == pulseFrequency) {
-		A = 115.72;
-		corrFac = 2.3334;
+		A = 115.72f;
+		corrFac = 2.3334f;
 	} else {
-		A = 121.74;
-		corrFac = 1.1667;
+		A = 121.74f;
+		corrFac = 1.1667f;
 	}
 
-	float estFpPwr = 10.0 * log10(base / (N * N)) - A;
+	float estFpPwr = 10.0f * log10f(base / (N * N)) - A;
 
 	if(estFpPwr <= -88) {
 		return estFpPwr;
@@ -861,7 +861,7 @@ float dwGetReceivePower(dwDevice_t* dev) {
   float C = (float)dwSpiRead16(dev, RX_FQUAL, CIR_PWR_SUB);
   float N = spiReadRxInfo(dev);
 
-  float twoPower17 = 131072.0;
+  float twoPower17 = 131072.0f;
 
   return calculatePower(C * twoPower17, N, dev->pulseFrequency);
 }

--- a/test/TestLibdw1000.c
+++ b/test/TestLibdw1000.c
@@ -316,7 +316,7 @@ static void verifyGdwGetFirstPathPower(uint16_t fpAmpl1, uint16_t fpAmpl2,
   float actual = dwGetFirstPathPower(&dev);
 
   // Assert
-  TEST_ASSERT_FLOAT_WITHIN(0.00001, expected, actual);
+  TEST_ASSERT_FLOAT_WITHIN(0.00002, expected, actual);
 }
 
 
@@ -335,5 +335,5 @@ static void verifyGetReceivePower(uint16_t cirPwr, uint8_t* rxFrameInfo, uint8_t
   float actual = dwGetReceivePower(&dev);
 
   // Assert
-  TEST_ASSERT_FLOAT_WITHIN(0.00001, expected, actual);
+  TEST_ASSERT_FLOAT_WITHIN(0.00003, expected, actual);
 }


### PR DESCRIPTION
Prevents double promotion to ensure the floating-point unit is used instead of software libraries.

Also see bitcraze/crazyflie-firmware#175