### PR TITLE
Added crystal calibration from OTP

### DIFF
--- a/inc/libdw1000Spi.h
+++ b/inc/libdw1000Spi.h
@@ -40,7 +40,7 @@ uint32_t dwSpiRead32(dwDevice_t *dev, uint8_t regid, uint32_t address);
  */
 void dwSpiWrite(dwDevice_t *dev, uint8_t regid, uint32_t address,
                                  const void* data, size_t length);
-
+void dwSpiWrite8(dwDevice_t *dev, uint8_t regid, uint32_t address, uint8_t data);
 void dwSpiWrite32(dwDevice_t *dev, uint8_t regid, uint32_t address,
                                   uint32_t data);
 

--- a/src/libdw1000.c
+++ b/src/libdw1000.c
@@ -50,6 +50,7 @@ const uint8_t MODE_LONGDATA_RANGE_ACCURACY[] = {TRX_RATE_110KBPS, TX_PULSE_FREQ_
 static void setBit(uint8_t data[], unsigned int n, unsigned int bit, bool val);
 static void writeValueToBytes(uint8_t data[], long val, unsigned int n);
 static bool getBit(uint8_t data[], unsigned int n, unsigned int bit);
+static void readBytesOTP(dwDevice_t* dev, const uint16_t address, uint8_t data[]);
 
 static void dummy(){
   ;
@@ -899,7 +900,7 @@ void dwTune(dwDevice_t *dev) {
 	uint8_t tcpgdelay[LEN_TC_PGDELAY];
 	uint8_t fspllcfg[LEN_FS_PLLCFG];
 	uint8_t fsplltune[LEN_FS_PLLTUNE];
-	// uint8_t fsxtalt[LEN_FS_XTALT];
+	uint8_t fsxtalt[LEN_FS_XTALT];
 	// AGC_TUNE1
 	if(dev->pulseFrequency == TX_PULSE_FREQ_16MHZ) {
 		writeValueToBytes(agctune1, 0x8870, LEN_AGC_TUNE1);
@@ -1217,8 +1218,15 @@ void dwTune(dwDevice_t *dev) {
 	} else {
 		// TODO proper error/warning handling
 	}
-	// mid range XTAL trim (TODO here we assume no calibration data available in OTP)
-	//writeValueToBytes(fsxtalt, 0x60, LEN_FS_XTALT);
+	// Crystal calibration from OTP (if available)
+	uint8_t buf_otp[4];
+	readBytesOTP(dev, 0x01E, buf_otp);
+	if (buf_otp[0] == 0) {
+		// No trim value available from OTP, use midrange value of 0x10
+		writeValueToBytes(fsxtalt, ((0x10 & 0x1F) | 0x60), LEN_FS_XTALT);
+	} else {
+		writeValueToBytes(fsxtalt, ((buf_otp[0] & 0x1F) | 0x60), LEN_FS_XTALT);
+	}
 	// write configuration back to chip
 	dwSpiWrite(dev, AGC_TUNE, AGC_TUNE1_SUB, agctune1, LEN_AGC_TUNE1);
 	dwSpiWrite(dev, AGC_TUNE, AGC_TUNE2_SUB, agctune2, LEN_AGC_TUNE2);
@@ -1237,7 +1245,7 @@ void dwTune(dwDevice_t *dev) {
 	dwSpiWrite(dev, TX_CAL, TC_PGDELAY_SUB, tcpgdelay, LEN_TC_PGDELAY);
 	dwSpiWrite(dev, FS_CTRL, FS_PLLTUNE_SUB, fsplltune, LEN_FS_PLLTUNE);
 	dwSpiWrite(dev, FS_CTRL, FS_PLLCFG_SUB, fspllcfg, LEN_FS_PLLCFG);
-	//dwSpiWrite(dev, FS_CTRL, FS_XTALT_SUB, fsxtalt, LEN_FS_XTALT);
+	dwSpiWrite(dev, FS_CTRL, FS_XTALT_SUB, fsxtalt, LEN_FS_XTALT);
 }
 
 // FIXME: This is a test!
@@ -1347,4 +1355,22 @@ static void writeValueToBytes(uint8_t data[], long val, unsigned int n) {
 	for(i = 0; i < n; i++) {
 		data[i] = ((val >> (i * 8)) & 0xFF);
 	}
+}
+
+static void readBytesOTP(dwDevice_t* dev, const uint16_t address, uint8_t data[]) {
+	uint8_t addressBytes[LEN_OTP_ADDR];
+
+	// p60 - 6.3.3 Reading a value from OTP memory
+	// bytes of address
+	addressBytes[0] = (address & 0xFF);
+	addressBytes[1] = ((address >> 8) & 0xFF);
+	// set address
+	dwSpiWrite(dev, OTP_IF, OTP_ADDR_SUB, addressBytes, LEN_OTP_ADDR);
+	// switch into read mode
+	dwSpiWrite8(dev, OTP_IF, OTP_CTRL_SUB, 0x03); // OTPRDEN | OTPREAD
+	dwSpiWrite8(dev, OTP_IF, OTP_CTRL_SUB, 0x01); // OTPRDEN
+	// read value/block - 4 bytes
+	dwSpiRead(dev, OTP_IF, OTP_RDAT_SUB, data, LEN_OTP_RDAT);
+	// end read mode
+	dwSpiWrite8(dev, OTP_IF, OTP_CTRL_SUB, 0x00);
 }

--- a/src/libdw1000Spi.c
+++ b/src/libdw1000Spi.c
@@ -83,6 +83,10 @@ void dwSpiWrite(dwDevice_t *dev, uint8_t regid, uint32_t address,
   dev->ops->spiWrite(dev, header, headerLength, data, length);
 }
 
+void dwSpiWrite8(dwDevice_t *dev, uint8_t regid, uint32_t address, uint8_t data) {
+  dwSpiWrite(dev, regid, address, &data, sizeof(data));
+}
+
 void dwSpiWrite32(dwDevice_t *dev, uint8_t regid, uint32_t address,
                                    uint32_t data) {
   dwSpiWrite(dev, regid, address, &data, sizeof(data));


### PR DESCRIPTION
As implemented in https://github.com/thotro/arduino-dw1000/pull/166
Solves the issues observed in https://github.com/bitcraze/crazyflie-firmware/pull/328 (where the required clock calibration goes over the maximum specified one).

> As part of the DWM1000 production the crystal has been trimmed and its trim value is stored in the OTP.

Source: https://www.decawave.com/faq-page/64#t64n477

For results, see attached videos of the required clock correction values before and after this change. Observe the values of the Y axis, where:
* Before the change, the required clock correction goes over the maximum specs: 1 + 2*(10*10^-6) (which after scaling it for better logging is 2000).
* After the change, it stays in values around 300, which is a clock correction of 1 + 0.3*(10*10^-6).

[ClockCorrectionBefore.zip](https://github.com/bitcraze/libdw1000/files/2143211/ClockCorrectionBefore.zip)
[ClockCorrectionAfter.zip](https://github.com/bitcraze/libdw1000/files/2143212/ClockCorrectionAfter.zip)

In addition, we can recalculate the maximum typical clock correction specs. According to the DW1000 datasheet:

> The crystal has been trimmed in production to reduce the initial frequency error to approximately 2 ppm, using the DW1000 IC’s internal on-chip crystal trimming circuit

Which means that the specs for clock frequency for one DW1000 are:
* Max typical specs: clkFreq + 2ppm
* Min typical specs: clkFreq - 2ppm

Which means that the specs for clock correction between **two** DW1000 are:
* Maximum error between the clkFreq of both DW1000: (clkFreq + 2ppm) - (clkFreq - 2ppm) = 4ppm
* Max typical clock correction specs: 1 + 4*10^-6
* Min typical clock correction specs: 1 - 4*10^-6