### PR TITLE
Added receiver only reset for fixing aleatory wrong timestamp meassurements

### DIFF
--- a/inc/dw1000.h
+++ b/inc/dw1000.h
@@ -96,7 +96,10 @@
 #define TXPRS_BIT 5
 #define TXPHS_BIT 6
 #define TXFRS_BIT 7
+#define RXPRD_BIT 8
+#define MRXSFDD_BIT 9
 #define LDEDONE_BIT 10
+#define MRXPHD_BIT 11
 #define RXPHE_BIT 12
 #define RXDFR_BIT 13
 #define RXFCG_BIT 14
@@ -104,8 +107,23 @@
 #define RXRFSL_BIT 16
 #define RXRFTO_BIT 17
 #define LDEERR_BIT 18
+// Bit 19 is reserved
+#define RXOVRR_BIT 20
+#define RXPTO_BIT 21
 #define RFPLL_LL_BIT 24
 #define CLKPLL_LL_BIT 25
+#define RXSFDTO_BIT 26
+#define AFFREJ_BIT 29
+
+// Helper masks. See: See: https://github.com/Decawave/dwm1001-examples/blob/master/deca_driver/deca_regs.h
+// All RX errors mask
+#define SYS_STATUS_ALL_RX_ERR (1 << RXPHE_BIT | 1 << RXFCE_BIT | 1 << RXRFSL_BIT | 1 << RXSFDTO_BIT | 1 << AFFREJ_BIT | 1 << LDEERR_BIT)
+// User defined RX timeouts (frame wait timeout and preamble detect timeout) mask
+#define SYS_STATUS_ALL_RX_TO (1 << RXRFTO_BIT | 1 << RXPTO_BIT)
+// All RX events after a correct packet reception mask
+#define SYS_STATUS_ALL_RX_GOOD (1 << RXDFR_BIT | 1 << RXFCG_BIT | 1 << RXPRD_BIT | 1 << MRXSFDD_BIT | 1 << MRXPHD_BIT | 1 << LDEDONE_BIT)
+// All TX events mask
+#define SYS_STATUS_ALL_TX (1 << AAT_BIT | 1 << TXFRB_BIT | 1 << TXPRS_BIT | 1 << TXPHS_BIT | 1 << TXFRS_BIT)
 
 // GPIO control register
 #define GPIO_CTRL 0x26

--- a/src/libdw1000.c
+++ b/src/libdw1000.c
@@ -249,6 +249,20 @@ void dwSoftReset(dwDevice_t* dev)
   dwIdle(dev);
 }
 
+/**
+ Reset the receiver. Needed after errors or timeouts.
+ From the DW1000 User Manual, v2.13 page 35: "Due to an issue in the re-initialisation of the receiver, it is necessary to apply a receiver reset after certain receiver error or timeout events (i.e. RXPHE (PHY Header Error), RXRFSL (Reed Solomon error), RXRFTO (Frame wait timeout), etc.). This ensures that the next good frame will have correctly calculated timestamp. It is not necessary to do this in the cases of RXPTO (Preamble detection Timeout) and RXSFDTO (SFD timeout). For details on how to apply a receiver-only reset see SOFTRESET field of Sub- Register 0x36:00 – PMSC_CTRL0."
+ */
+void dwRxSoftReset(dwDevice_t* dev) {
+	uint8_t pmscctrl0[LEN_PMSC_CTRL0];
+	dwSpiRead(dev, PMSC, PMSC_CTRL0_SUB, pmscctrl0, LEN_PMSC_CTRL0);
+
+	pmscctrl0[3] = pmscctrl0[3] & 0xEF;
+	dwSpiWrite(dev, PMSC, PMSC_CTRL0_SUB, pmscctrl0, LEN_PMSC_CTRL0);
+	pmscctrl0[3] = pmscctrl0[3] | 0x10;
+	dwSpiWrite(dev, PMSC, PMSC_CTRL0_SUB, pmscctrl0, LEN_PMSC_CTRL0);
+}
+
 /* ###########################################################################
  * #### DW1000 register read/write ###########################################
  * ######################################################################### */
@@ -358,10 +372,13 @@ void dwInterruptOnReceiveFailed(dwDevice_t* dev, bool val) {
 	setBit(dev->sysmask, LEN_SYS_STATUS, RXFCE_BIT, val);
 	setBit(dev->sysmask, LEN_SYS_STATUS, RXPHE_BIT, val);
 	setBit(dev->sysmask, LEN_SYS_STATUS, RXRFSL_BIT, val);
+	setBit(dev->sysmask, LEN_SYS_MASK, RXSFDTO_BIT, val);
+	setBit(dev->sysmask, LEN_SYS_MASK, AFFREJ_BIT, val);
 }
 
 void dwInterruptOnReceiveTimeout(dwDevice_t* dev, bool val) {
 	setBit(dev->sysmask, LEN_SYS_MASK, RXRFTO_BIT, val);
+	setBit(dev->sysmask, LEN_SYS_MASK, RXPTO_BIT, val);
 }
 
 void dwInterruptOnReceiveTimestampAvailable(dwDevice_t* dev, bool val) {
@@ -753,19 +770,11 @@ bool dwIsReceiveDone(dwDevice_t* dev) {
 }
 
 bool dwIsReceiveFailed(dwDevice_t *dev) {
-	bool ldeErr, rxCRCErr, rxHeaderErr, rxDecodeErr;
-	ldeErr = getBit(dev->sysstatus, LEN_SYS_STATUS, LDEERR_BIT);
-	rxCRCErr = getBit(dev->sysstatus, LEN_SYS_STATUS, RXFCE_BIT);
-	rxHeaderErr = getBit(dev->sysstatus, LEN_SYS_STATUS, RXPHE_BIT);
-	rxDecodeErr = getBit(dev->sysstatus, LEN_SYS_STATUS, RXRFSL_BIT);
-	if(ldeErr || rxCRCErr || rxHeaderErr || rxDecodeErr) {
-		return true;
-	}
-	return false;
+	return *(uint32_t*)dev->sysstatus & SYS_STATUS_ALL_RX_ERR;
 }
 
 bool dwIsReceiveTimeout(dwDevice_t* dev) {
-	return getBit(dev->sysstatus, LEN_SYS_STATUS, RXRFTO_BIT);
+	return *(uint32_t*)dev->sysstatus & SYS_STATUS_ALL_RX_TO;
 }
 
 bool dwIsClockProblem(dwDevice_t* dev) {
@@ -792,26 +801,14 @@ void dwClearReceiveTimestampAvailableStatus(dwDevice_t* dev) {
 
 void dwClearReceiveStatus(dwDevice_t* dev) {
 	// clear latched RX bits (i.e. write 1 to clear)
-  uint8_t reg[LEN_SYS_STATUS] = {0};
-	setBit(reg, LEN_SYS_STATUS, RXDFR_BIT, true);
-	setBit(reg, LEN_SYS_STATUS, LDEDONE_BIT, true);
-	setBit(reg, LEN_SYS_STATUS, LDEERR_BIT, true);
-	setBit(reg, LEN_SYS_STATUS, RXPHE_BIT, true);
-	setBit(reg, LEN_SYS_STATUS, RXFCE_BIT, true);
-	setBit(reg, LEN_SYS_STATUS, RXFCG_BIT, true);
-	setBit(reg, LEN_SYS_STATUS, RXRFSL_BIT, true);
-  setBit(reg, LEN_SYS_STATUS, RXRFTO_BIT, true);
-	dwSpiWrite(dev, SYS_STATUS, NO_SUB, reg, LEN_SYS_STATUS);
+	uint32_t regData = SYS_STATUS_ALL_RX_TO | SYS_STATUS_ALL_RX_ERR | SYS_STATUS_ALL_RX_GOOD;
+	dwSpiWrite32(dev, SYS_STATUS, NO_SUB, regData);
 }
 
 void dwClearTransmitStatus(dwDevice_t* dev) {
 	// clear latched TX bits
-  uint8_t reg[LEN_SYS_STATUS] = {0};
-	setBit(reg, LEN_SYS_STATUS, TXFRB_BIT, true);
-	setBit(reg, LEN_SYS_STATUS, TXPRS_BIT, true);
-	setBit(reg, LEN_SYS_STATUS, TXPHS_BIT, true);
-	setBit(reg, LEN_SYS_STATUS, TXFRS_BIT, true);
-	dwSpiWrite(dev, SYS_STATUS, NO_SUB, reg, LEN_SYS_STATUS);
+	uint32_t regData = SYS_STATUS_ALL_TX;
+	dwSpiWrite32(dev, SYS_STATUS, NO_SUB, regData);
 }
 
 float dwGetReceiveQuality(dwDevice_t* dev) {
@@ -1273,19 +1270,25 @@ void dwHandleInterrupt(dwDevice_t *dev) {
     dwClearReceiveTimestampAvailableStatus(dev);
 		(*_handleReceiveTimestampAvailable)();
 	}
-	if(dwIsReceiveFailed(dev) && dev->handleReceiveFailed != 0) {
-    dwClearReceiveStatus(dev);
-		dev->handleReceiveFailed(dev);
-		if(dev->permanentReceive) {
-			dwNewReceive(dev);
-			dwStartReceive(dev);
+	if(dwIsReceiveFailed(dev)) {
+		dwClearReceiveStatus(dev);
+		dwRxSoftReset(dev); // Needed due to error in the RX auto-re-enable functionnality. See page 35 of DW1000 manual, v2.13.
+		if(dev->handleReceiveFailed != 0) {
+			dev->handleReceiveFailed(dev);
+			if(dev->permanentReceive) {
+				dwNewReceive(dev);
+				dwStartReceive(dev);
+			}
 		}
-	} else if(dwIsReceiveTimeout(dev) && dev->handleReceiveTimeout != 0) {
-    dwClearReceiveStatus(dev);
-		(*dev->handleReceiveTimeout)(dev);
-		if(dev->permanentReceive) {
-			dwNewReceive(dev);
-			dwStartReceive(dev);
+	} else if(dwIsReceiveTimeout(dev)) {
+		dwClearReceiveStatus(dev);
+		dwRxSoftReset(dev); // Needed due to error in the RX auto-re-enable functionnality. See page 35 of DW1000 manual, v2.13.
+		if(dev->handleReceiveTimeout != 0) {
+			(*dev->handleReceiveTimeout)(dev);
+			if(dev->permanentReceive) {
+				dwNewReceive(dev);
+				dwStartReceive(dev);
+			}
 		}
 	} else if(dwIsReceiveDone(dev) && dev->handleReceived != 0) {
     dwClearReceiveStatus(dev);

--- a/src/libdw1000.c
+++ b/src/libdw1000.c
@@ -1272,7 +1272,7 @@ void dwHandleInterrupt(dwDevice_t *dev) {
 	}
 	if(dwIsReceiveFailed(dev)) {
 		dwClearReceiveStatus(dev);
-		dwRxSoftReset(dev); // Needed due to error in the RX auto-re-enable functionnality. See page 35 of DW1000 manual, v2.13.
+		dwRxSoftReset(dev); // Needed due to error in the RX auto-re-enable functionality. See page 35 of DW1000 manual, v2.13.
 		if(dev->handleReceiveFailed != 0) {
 			dev->handleReceiveFailed(dev);
 			if(dev->permanentReceive) {
@@ -1282,7 +1282,7 @@ void dwHandleInterrupt(dwDevice_t *dev) {
 		}
 	} else if(dwIsReceiveTimeout(dev)) {
 		dwClearReceiveStatus(dev);
-		dwRxSoftReset(dev); // Needed due to error in the RX auto-re-enable functionnality. See page 35 of DW1000 manual, v2.13.
+		dwRxSoftReset(dev); // Needed due to error in the RX auto-re-enable functionality. See page 35 of DW1000 manual, v2.13.
 		if(dev->handleReceiveTimeout != 0) {
 			(*dev->handleReceiveTimeout)(dev);
 			if(dev->permanentReceive) {


### PR DESCRIPTION
Added receiver only reset for fixing aleatory wrong timestamp meassurements, needed due to error in the RX auto-re-enable functionnality. See page 35 of DW1000 manual, v2.13:

> Note: Due to an issue in the re-initialisation of the receiver, it is necessary to apply a receiver reset after certain receiver error or timeout events (i.e. RXPHE (PHY Header Error), RXRFSL (Reed Solomon error), RXRFTO (Frame wait timeout), etc.). This ensures that the next good frame will have correctly calculated timestamp. It is not necessary to do this in the cases of RXPTO (Preamble detection Timeout) and RXSFDTO (SFD timeout). For details on how to apply a receiver-only reset see SOFTRESET field of Sub- Register 0x36:00 – PMSC_CTRL0.

In terms of tof, this PR avoids aleatory spikes in tof meassurements:
![captura de pantalla 2018-07-03 a las 15 03 55](https://user-images.githubusercontent.com/7938671/42221455-57e4ea0c-7ed2-11e8-91f7-ef6ce8e9467a.png)

Also, added handling for more errors and timeouts according to what seems to be the official Decawave DW1000 C driver (https://github.com/Decawave/dwm1001-examples/blob/master/deca_driver/deca_regs.h).

Also, seems like due to this error with the RX auto-re-enable functionnality, Decawave recommends to use manual RX re-enable. See: https://www.decawave.com/decaforum/showthread.php?tid=613

